### PR TITLE
Fix PHPDoc typehint for options return value

### DIFF
--- a/src/Checkboxes.php
+++ b/src/Checkboxes.php
@@ -18,7 +18,7 @@ class Checkboxes extends Field
      * Specify the available options
      *
      * @param array $options
-     * @return void
+     * @return self
      */
     public function options(array $options)
     {


### PR DESCRIPTION
My IDE (PHPStorm) was complaining about `options()` returning `void`.