### PR TITLE
Fix: If nothing is selected returns [""] instead of []

### DIFF
--- a/src/Checkboxes.php
+++ b/src/Checkboxes.php
@@ -44,7 +44,7 @@ class Checkboxes extends Field
             if (!is_array($choices = $request[$requestAttribute])) {
                 $choices = collect(explode(',', $choices))->map(function ($choice) {
                     return $this->castValueToType($choice);
-                })->all();
+                })->filter()->all();
             }
 
             $model->{$attribute} = $choices;


### PR DESCRIPTION
Currently when nothing is selected explode will return an array with single empty string `[""]`.
The correct result should be an empty array `[]`.

This fix will change this behavior to more correct one.
Change might be breaking so I suggest bumping version number.
