### PR TITLE
Add the ability to customize the displayed number of options columns

### DIFF
--- a/README.md
+++ b/README.md
@@ -34,6 +34,17 @@ Checkboxes::make('Permissions')->options([
 ]->withoutTypeCasting()),
 ```
 
+You can also customise the number of columns in which options will be displayed by calling `columns()`
+
+```php
+use Silvanite\NovaFieldCheckboxes\Checkboxes;
+
+Checkboxes::make('Permissions')->options([
+    1 => 'Access Admin UI',
+    2 => 'Manage Users',
+])->columns(4),
+```
+
 ### Example using eloquent
 
 Here is an example of how you might use an eloquent model with Checkboxes.

--- a/resources/js/components/DetailField.vue
+++ b/resources/js/components/DetailField.vue
@@ -1,7 +1,10 @@
 <template>
     <panel-item :field="field">
         <p slot="value" class="text-90 flex">
-            <span class="w-full max-col-2">
+            <span
+                :style="{columnCount: this.field.columns}"
+                class="w-full max-col-2"
+            >
                 <div
                     v-for="(label, option) in field.options"
                     :key="option"
@@ -34,13 +37,6 @@ export default {
 </script>
 
 <style>
-    .max-col-3 {
-        -moz-column-count: 3;
-        -webkit-column-count: 3;
-        column-count: 3;
-        white-space: nowrap;
-    }
-
     .max-col-2 {
         -moz-column-count: 2;
         -webkit-column-count: 2;
@@ -48,4 +44,3 @@ export default {
         white-space: nowrap;
     }
 </style>
-

--- a/resources/js/components/FormField.vue
+++ b/resources/js/components/FormField.vue
@@ -1,7 +1,10 @@
 <template>
-    <default-field :field="field">
+    <default-field :field="field" full-width-content>
         <template slot="field">
-            <div class="w-full max-col-2">
+            <div
+                :style="{columnCount: this.field.columns}"
+                class="w-full max-col-2"
+            >
                 <div
                     v-for="(label, option) in field.options"
                     :key="option"
@@ -76,13 +79,6 @@ export default {
 </script>
 
 <style>
-    .max-col-3 {
-        -moz-column-count: 3;
-        -webkit-column-count: 3;
-        column-count: 3;
-        white-space: nowrap;
-    }
-
     .max-col-2 {
         -moz-column-count: 2;
         -webkit-column-count: 2;

--- a/src/Checkboxes.php
+++ b/src/Checkboxes.php
@@ -15,6 +15,26 @@ class Checkboxes extends Field
     public $component = 'novafieldcheckboxes';
 
     /**
+     * The meta data for the element.
+     *
+     * @var array
+     */
+    public $meta = [
+        'columns' => 2,
+    ];
+
+    /**
+     * Specify the number of columns.
+     *
+     * @param array $columns
+     * @return self
+     */
+    public function columns(int $columns)
+    {
+        return $this->withMeta(['columns' => $columns]);
+    }
+
+    /**
      * Specify the available options
      *
      * @param array $options


### PR DESCRIPTION
This PR sets full width content for the form field and adds the function `columns()` to define the number of option columns to display