### PR TITLE
Fix overflow of labels on details and form screens.

### DIFF
--- a/resources/js/components/DetailField.vue
+++ b/resources/js/components/DetailField.vue
@@ -14,7 +14,7 @@
                         class="inline-block rounded-full w-2 h-2 mr-1"
                         :class="optionClass(option)"
                     />
-                    <span>{{ label }}</span>
+                    <span class="whitespace-normal">{{ label }}</span>
                 </div>
             </span>
         </p>

--- a/resources/js/components/FormField.vue
+++ b/resources/js/components/FormField.vue
@@ -20,7 +20,7 @@
                         :for="field.name"
                         v-text="label"
                         @click="toggleOption(option)"
-                        class="w-full leading-tight"
+                        class="w-full leading-tight whitespace-normal"
                     ></label>
                 </div>
             </div>


### PR DESCRIPTION
This PR fix the overflow of labels on detail and form screens.

**Issue screenshots:**
![CopyQ ZVCuTv](https://user-images.githubusercontent.com/47752310/146787596-0ec3f234-012c-4e82-9ddf-f46a4de7db70.png)
![CopyQ WBsAKn](https://user-images.githubusercontent.com/47752310/146787603-25563b47-b3d5-470c-be44-6eae222410e7.png)

